### PR TITLE
Adding PI identifier to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -34,6 +34,11 @@
      "firstName": "Ali",
      "middleInitial": "R.",
      "lastName": "Khan",
+     "roles": [
+		{
+			"value": "Principal Investigator"
+		}
+     ],
      "affiliations":
      [
        {


### PR DESCRIPTION
This PR adds the value of "Principal Investigator" in` roles->name` for Ali Khan under creators in the DATS.json file.